### PR TITLE
Fix sending post requests

### DIFF
--- a/src/Teamleader.php
+++ b/src/Teamleader.php
@@ -186,7 +186,7 @@ final class Teamleader
             }
 
             $body = $this->streamFactory->createStream($encodedParameters);
-            $request->withBody($body);
+            $request = $request->withBody($body);
         }
 
         $response = $this->client->sendRequest($request);


### PR DESCRIPTION
During the refactor of get and post methods this bug was introduced, when setting the body, that method returns an modified object with the supplied body (immutable).